### PR TITLE
chore(terraform): remove domain handling from AWS

### DIFF
--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -1,7 +1,0 @@
-resource "aws_route53_zone" "primary" {
-  name = var.app_domain
-
-  tags = {
-    Name = var.app_domain
-  }
-}

--- a/terraform/email.tf
+++ b/terraform/email.tf
@@ -1,34 +1,27 @@
-resource "aws_ses_domain_identity" "email" {
-  domain = var.app_domain
+## Domain Identity
+
+resource "aws_ses_domain_identity" "email_domain" {
+  domain = var.email_domain
 }
 
-resource "aws_ses_configuration_set" "default" {
-  name = "default_configuration_set"
+# Ownership validation
 
-  delivery_options {
-    tls_policy = "Require"
-  }
+output "email_domain_verification_token" {
+  value = aws_ses_domain_identity.email_domain.verification_token
 }
 
-# TODO assign default configuration set
-
-resource "aws_ses_domain_dkim" "email" {
-  domain = aws_ses_domain_identity.email.domain
+resource "aws_ses_domain_identity_verification" "email_domain_verification" {
+  domain = aws_ses_domain_identity.email_domain.domain
 }
 
-resource "aws_route53_record" "email_dkim_record" {
-  count   = 3
-  zone_id = aws_route53_zone.primary.zone_id
-  name    = "${element(aws_ses_domain_dkim.email.dkim_tokens, count.index)}._domainkey"
-  type    = "CNAME"
-  ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.email.dkim_tokens, count.index)}.dkim.amazonses.com"]
+# DKIM
+
+resource "aws_ses_domain_dkim" "email_domain" {
+  domain = aws_ses_domain_identity.email_domain.domain
 }
 
-resource "aws_ses_domain_identity_verification" "email_verification" {
-  domain = aws_ses_domain_identity.email.id
-
-  depends_on = [aws_route53_record.email_dkim_record]
+output "email_domain_dkim_tokens" {
+  value = aws_ses_domain_dkim.email_domain.dkim_tokens
 }
 
 resource "aws_iam_user" "ses" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,8 +2,8 @@ variable "app_name" {
   description = "The name of the app"
 }
 
-variable "app_domain" {
-  description = "The domain where the app is hosted"
+variable "email_domain" {
+  description = "The domain used for sending emails"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## Why?

In the continuation of #430, let's remove more dependency to AWS, and become 100% self-hostable.

## What?

Remove the domain handling from AWS.

Sending emails is still done using AWS SES, the expected DNS records are outputed by Terraform.
