### PR TITLE
chore(ci): use different concurrency groups in workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
 # Prevent concurrent runs on the same branch. In case of conflict,
 # the oldest run will be cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-push-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 # Prevent concurrent runs on the same branch. In case of conflict,
 # the oldest run will be cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-test-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Why? 

The "push" workflow is being cancelled by the "test" one - which it calls.

## What?

Use different concurrency groups.