### PR TITLE
chore(monitoring): add `/metrics/version` HTTP route

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,7 @@
 erl_crash.dump
 
 # Static artifacts - These should be fetched and built inside the Docker image
+# https://phoenix.hexdocs.pm/Mix.Tasks.Phx.Gen.Release.html#module-docker
 /assets/node_modules/
 /priv/static/assets/
 /priv/static/cache_manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,9 @@ COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
 COPY priv priv
-
 COPY lib lib
-
 COPY assets assets
+COPY .git .git
 
 # compile assets
 RUN mix assets.deploy

--- a/lib/app/version.ex
+++ b/lib/app/version.ex
@@ -1,0 +1,36 @@
+defmodule App.Version do
+  @moduledoc """
+  This module embeds the application version, which is currently represented by the Git
+  commit hash used when building the application.
+
+  ## Why embed the version at compile-time?
+
+  This ensures it is not overwritten by any kind of runtime configuration.
+
+  ## Why read files here instead of in `config.exs`?
+
+  To optimize the Docker image cache. Using `config.exs`, the information would need
+  to be set when building dependencies with `mix deps.compile`. This implies the `.git`
+  directory must be copied before compiling the dependencies, which would invalidate
+  the cache even when dependencies did not change.
+  """
+
+  # The HEAD contains either `ref: refs/heads/...`
+  # or a commit hash directly.
+  case File.read(".git/HEAD") do
+    {:ok, "ref: " <> ref} ->
+      @app_version File.read!(".git/#{String.trim(ref)}") |> String.trim()
+
+    {:ok, commit_sha} when byte_size(commit_sha) > 0 ->
+      @app_version String.trim(commit_sha)
+
+    {:error, _reason} ->
+      if Mix.env() == :prod do
+        raise "Could not compile: git commit not found"
+      else
+        @app_version "not_found"
+      end
+  end
+
+  def version, do: @app_version
+end

--- a/lib/app_web/controllers/metrics/metrics_controller.ex
+++ b/lib/app_web/controllers/metrics/metrics_controller.ex
@@ -8,4 +8,8 @@ defmodule AppWeb.MetricsController do
   def health_check(conn, _opts) do
     text(conn, "OK")
   end
+
+  def version(conn, _opts) do
+    text(conn, App.Version.version())
+  end
 end

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -124,6 +124,7 @@ defmodule AppWeb.Router do
 
   scope "/", AppWeb do
     get "/metrics/health_check", MetricsController, :health_check
+    get "/metrics/version", MetricsController, :version
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## Why?

Need to know which version is the app currently running, this can be handy to know if a deployment went well, or something.

## What?

Expose a new route `/metrics/version` that returns the Git commit the app was built upon.
