### PR TITLE
perf(ci): use GitHub Actions cache when building Docker image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,6 +39,8 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           # By default, the context is the git context. Set it to the current
           # directory to include make sure `.git` directory is available.
           context: .


### PR DESCRIPTION
## Why?

The Docker image build is slow. A minimal, easy, first optimization is to use GitHub Actions build-in cache.

## What?

Add cache when building Docker image (note: not when testing that the image builds correctly)
