### PR TITLE
fix(web, avatars): revert user differentiation

### DIFF
--- a/lib/app_web/live/books/book_member_live.ex
+++ b/lib/app_web/live/books/book_member_live.ex
@@ -28,7 +28,14 @@ defmodule AppWeb.BookMemberLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.member_hero_avatar book_member={@book_member} />
+      <%= if @user do %>
+        <.member_hero_avatar book_member={@book_member} />
+      <% else %>
+        <div class="text-center my-4">
+          <.icon name={:user_circle} class="block size-[8rem] mx-auto" />
+          <span class="label">{@book_member.nickname}</span>
+        </div>
+      <% end %>
 
       <.alert_flash flash={@flash} kind={:error} class="mb-4" />
 

--- a/lib/app_web/live/books/book_members_live.ex
+++ b/lib/app_web/live/books/book_members_live.ex
@@ -73,7 +73,15 @@ defmodule AppWeb.BookMembersLive do
   end
 
   defp member_avatar(assigns) do
-    ~H|<.avatar name={@member.nickname} />|
+    if has_user?(assigns.member) do
+      ~H|<.avatar name={@member.nickname} />|
+    else
+      ~H|<.icon name={:user_circle} class="m-1" />|
+    end
+  end
+
+  defp has_user?(book_member) do
+    book_member.user_id != nil
   end
 
   @impl Phoenix.LiveView


### PR DESCRIPTION
## Why?

In #474, I removed the dissociation between "linked" and "unlinked" book members (aka, book members associated with a user or not). But this visual dissociation is useful when looking at the members of a book! It allows seeing who has access to the book.

## What?

Bring it back.
