### PR TITLE
fix(web): add missing `id` attribute on LiveView forms

### DIFF
--- a/lib/app_web/live/books/book_configuration_name_live.ex
+++ b/lib/app_web/live/books/book_configuration_name_live.ex
@@ -21,7 +21,13 @@ defmodule AppWeb.BookConfigurationNameLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.form for={@form} phx-change="validate" phx-submit="submit" class="container space-y-2">
+      <.form
+        for={@form}
+        id="book-name-form"
+        phx-change="validate"
+        phx-submit="submit"
+        class="container space-y-2"
+      >
         <p>
           {gettext("This is the current name of the book")}<br />
           <span class="label">{@book.name}</span>

--- a/lib/app_web/live/books/book_creation_live.ex
+++ b/lib/app_web/live/books/book_creation_live.ex
@@ -16,7 +16,13 @@ defmodule AppWeb.BookCreationLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.form for={@form} phx-change="validate" phx-submit="submit" class="container space-y-4">
+      <.form
+        for={@form}
+        id="book-creation-form"
+        phx-change="validate"
+        phx-submit="submit"
+        class="container space-y-4"
+      >
         <p>{gettext("What do you want to call your new book?")}</p>
 
         <.input

--- a/lib/app_web/live/books/book_member_revenues_live.ex
+++ b/lib/app_web/live/books/book_member_revenues_live.ex
@@ -19,7 +19,7 @@ defmodule AppWeb.BookMemberRevenuesLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.form for={@form} phx-change="validate" phx-submit="submit">
+      <.form for={@form} id="revenues-form" phx-change="validate" phx-submit="submit">
         <section class="container space-y-2 mb-4">
           <p>{revenues_balance_config_paragraph(assigns)}</p>
           <p>{gettext("What would you like to set them to?")}</p>

--- a/lib/app_web/live/books/book_reimbursement_creation_live.ex
+++ b/lib/app_web/live/books/book_reimbursement_creation_live.ex
@@ -22,7 +22,13 @@ defmodule AppWeb.BookReimbursementCreationLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.form for={@form} phx-change="validate" phx-submit="submit" class="container">
+      <.form
+        for={@form}
+        id="reimbursement-form"
+        phx-change="validate"
+        phx-submit="submit"
+        class="container"
+      >
         <section class="grid grid-cols-2 gap-y-2 gap-x-4 mb-4">
           <div class="col-span-2">
             <.input field={@form[:label]} type="text" label={gettext("Label")} required />

--- a/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/lib/app_web/live/books/book_transfer_form_live.ex
@@ -31,7 +31,13 @@ defmodule AppWeb.BookTransferFormLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.form for={@form} phx-change="validate" phx-submit="submit" class="space-y-4">
+      <.form
+        for={@form}
+        id="transfer-form"
+        phx-change="validate"
+        phx-submit="submit"
+        class="space-y-4"
+      >
         <section id="details" class="container space-y-2">
           <h2 class="title-2">{gettext("Details")}</h2>
 


### PR DESCRIPTION
## Why?

When running tests, Phoenix LiveView is warning about form that may fail recovery because they miss an ID.

## What?

Add an ID to all forms within live views.