### PR TITLE
chore(repo): add seeds when initializing database

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,70 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+## Accounts
+
+alias App.Accounts
+
+{:ok, user} =
+  Accounts.register_user(%{
+    email: "anacounts@example.com",
+    password: "azertyuiop12345!"
+  })
+
+{:ok, user_2} =
+  Accounts.register_user(%{
+    email: "member_2@example.com",
+    password: "azertyuiop12345!"
+  })
+
+## Books
+
+alias App.Books
+alias App.Books.Members
+
+{:ok, book} = Books.create_book(%{name: "Sample Book", nickname: "Anacounts"}, user)
+
+{:ok, member_2} = Members.create_book_member_for_user(book, user_2, %{nickname: "Member 2"})
+{:ok, member_3} = Members.create_book_member(book, %{nickname: "Member 3"})
+{:ok, member_4} = Members.create_book_member(book, %{nickname: "Member 4"})
+
+## Money transfers
+
+alias App.Transfers
+
+{:ok, _payment} =
+  Transfers.create_money_transfer(book, member_2, :payment, %{
+    tenant_id: member_2.id,
+    label: "Groceries",
+    amount: Decimal.new("42.50"),
+    date: ~D[2026-07-01],
+    balance_means: :divide_equally,
+    peers: [
+      %{member_id: member_2.id},
+      %{member_id: member_3.id},
+      %{member_id: member_4.id}
+    ]
+  })
+
+{:ok, _income} =
+  Transfers.create_money_transfer(book, member_2, :income, %{
+    tenant_id: member_2.id,
+    label: "Refund from supplier",
+    amount: Decimal.new("15.00"),
+    date: ~D[2026-07-03],
+    balance_means: :divide_equally,
+    peers: [
+      %{member_id: member_2.id},
+      %{member_id: member_3.id}
+    ]
+  })
+
+{:ok, _reimbursement} =
+  Transfers.create_reimbursement(book, %{
+    label: "Reimbursement from Member 2 to Anacounts",
+    amount: Decimal.new("20.00"),
+    date: ~D[2026-07-05],
+    tenant_id: member_3.id,
+    peers: [%{member_id: member_2.id}]
+  })

--- a/test/app_web/live/books/book_transfer_form_live_test.exs
+++ b/test/app_web/live/books/book_transfer_form_live_test.exs
@@ -109,7 +109,8 @@ defmodule AppWeb.BookTransferFormLiveTest do
     assert html =~ "Updated transfer"
 
     new_peer_ids =
-      Peer
+      money_transfer
+      |> Peer.transfer_query()
       |> Repo.all()
       |> Enum.map(& &1.id)
 


### PR DESCRIPTION
## Why?

Help speed up database initialization after the database has been created or reset.

## What?

Add seeds for: users, books, members, money transfers.