### PR TITLE
chore(layouts): move `<.alert_flash>` to `<.app_page>` component

### DIFF
--- a/lib/app_web/components/page_components.ex
+++ b/lib/app_web/components/page_components.ex
@@ -21,6 +21,8 @@ defmodule AppWeb.PageComponents do
   It includes the breadcrumb, title, and the main content of the page.
   """
 
+  attr :flash, :map, required: true, doc: "The @flash assign"
+
   slot :breadcrumb, required: true
   slot :title, required: true
 
@@ -35,6 +37,7 @@ defmodule AppWeb.PageComponents do
         <h1 class="title-1 truncate">{render_slot(@title)}</h1>
       </header>
       <main>
+        <.alert_flash :for={kind <- [:info, :error]} flash={@flash} kind={kind} class="mb-4" />
         {render_slot(@inner_block)}
       </main>
     </div>

--- a/lib/app_web/live/accounts/user_settings_email_live.ex
+++ b/lib/app_web/live/accounts/user_settings_email_live.ex
@@ -16,9 +16,6 @@ defmodule AppWeb.UserSettingsEmailLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.alert_flash flash={@flash} kind={:info} class="mb-4" />
-      <.alert_flash flash={@flash} kind={:error} class="mb-4" />
-
       <.form
         for={@form}
         id="email_form"

--- a/lib/app_web/live/accounts/user_settings_email_live.ex
+++ b/lib/app_web/live/accounts/user_settings_email_live.ex
@@ -5,7 +5,7 @@ defmodule AppWeb.UserSettingsEmailLive do
 
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/users/settings"}>
           {gettext("My account")}

--- a/lib/app_web/live/accounts/user_settings_live.ex
+++ b/lib/app_web/live/accounts/user_settings_live.ex
@@ -3,7 +3,7 @@ defmodule AppWeb.UserSettingsLive do
 
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item>
           {@page_title}

--- a/lib/app_web/live/accounts/user_settings_password_live.ex
+++ b/lib/app_web/live/accounts/user_settings_password_live.ex
@@ -5,7 +5,7 @@ defmodule AppWeb.UserSettingsPasswordLive do
 
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/users/settings"}>
           {gettext("My account")}

--- a/lib/app_web/live/books/book_balance_live.ex
+++ b/lib/app_web/live/books/book_balance_live.ex
@@ -14,7 +14,7 @@ defmodule AppWeb.BookBalanceLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/books/#{@book}"}>
           {@book.name}

--- a/lib/app_web/live/books/book_configuration_live.ex
+++ b/lib/app_web/live/books/book_configuration_live.ex
@@ -8,7 +8,7 @@ defmodule AppWeb.BookConfigurationLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/books/#{@book}"}>
           {@book.name}

--- a/lib/app_web/live/books/book_configuration_name_live.ex
+++ b/lib/app_web/live/books/book_configuration_name_live.ex
@@ -9,7 +9,7 @@ defmodule AppWeb.BookConfigurationNameLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/configuration"}>

--- a/lib/app_web/live/books/book_creation_live.ex
+++ b/lib/app_web/live/books/book_creation_live.ex
@@ -8,7 +8,7 @@ defmodule AppWeb.BookCreationLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item>
           {@page_title}

--- a/lib/app_web/live/books/book_invitations_live.ex
+++ b/lib/app_web/live/books/book_invitations_live.ex
@@ -13,7 +13,7 @@ defmodule AppWeb.BookInvitationsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/members"}>

--- a/lib/app_web/live/books/book_live.ex
+++ b/lib/app_web/live/books/book_live.ex
@@ -22,8 +22,6 @@ defmodule AppWeb.BookLive do
       </:breadcrumb>
       <:title>{@page_title}</:title>
 
-      <.alert_flash flash={@flash} kind={:info} class="mb-4" />
-
       <.link :if={@no_revenues?} navigate={~p"/books/#{@book}/profile"}>
         <.alert kind={:warning}>
           <span class="grow">{gettext("Your revenues are not set")}</span>

--- a/lib/app_web/live/books/book_live.ex
+++ b/lib/app_web/live/books/book_live.ex
@@ -16,7 +16,7 @@ defmodule AppWeb.BookLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item>{@page_title}</.breadcrumb_item>
       </:breadcrumb>

--- a/lib/app_web/live/books/book_member_creation_live.ex
+++ b/lib/app_web/live/books/book_member_creation_live.ex
@@ -14,7 +14,7 @@ defmodule AppWeb.BookMemberCreationLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/members"}>

--- a/lib/app_web/live/books/book_member_live.ex
+++ b/lib/app_web/live/books/book_member_live.ex
@@ -16,7 +16,7 @@ defmodule AppWeb.BookMemberLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/members"}>

--- a/lib/app_web/live/books/book_member_live.ex
+++ b/lib/app_web/live/books/book_member_live.ex
@@ -37,8 +37,6 @@ defmodule AppWeb.BookMemberLive do
         </div>
       <% end %>
 
-      <.alert_flash flash={@flash} kind={:error} class="mb-4" />
-
       <.card_grid>
         <.balance_card_link book_member={@book_member} />
         <.card>

--- a/lib/app_web/live/books/book_member_nickname_live.ex
+++ b/lib/app_web/live/books/book_member_nickname_live.ex
@@ -10,7 +10,7 @@ defmodule AppWeb.BookMemberNicknameLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         {nickname_breadcrumbs(assigns)}
       </:breadcrumb>

--- a/lib/app_web/live/books/book_member_revenues_live.ex
+++ b/lib/app_web/live/books/book_member_revenues_live.ex
@@ -13,7 +13,7 @@ defmodule AppWeb.BookMemberRevenuesLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         {revenues_breadcrumbs(assigns)}
       </:breadcrumb>

--- a/lib/app_web/live/books/book_member_revenues_transfers_live.ex
+++ b/lib/app_web/live/books/book_member_revenues_transfers_live.ex
@@ -17,7 +17,7 @@ defmodule AppWeb.BookMemberRevenuesTransfersLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         {revenues_breadcrumbs(assigns)}
       </:breadcrumb>

--- a/lib/app_web/live/books/book_members_live.ex
+++ b/lib/app_web/live/books/book_members_live.ex
@@ -17,7 +17,7 @@ defmodule AppWeb.BookMembersLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/books/#{@book}"}>
           {@book.name}

--- a/lib/app_web/live/books/book_profile_live.ex
+++ b/lib/app_web/live/books/book_profile_live.ex
@@ -10,7 +10,7 @@ defmodule AppWeb.BookProfileLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/books/#{@book}"}>
           {@book.name}

--- a/lib/app_web/live/books/book_reimbursement_creation_live.ex
+++ b/lib/app_web/live/books/book_reimbursement_creation_live.ex
@@ -10,7 +10,7 @@ defmodule AppWeb.BookReimbursementCreationLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/balance"}>

--- a/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/lib/app_web/live/books/book_transfer_form_live.ex
@@ -21,7 +21,7 @@ defmodule AppWeb.BookTransferFormLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_ellipsis />
         <.breadcrumb_item navigate={~p"/books/#{@book}/transfers"}>

--- a/lib/app_web/live/books/book_transfers_live.ex
+++ b/lib/app_web/live/books/book_transfers_live.ex
@@ -20,7 +20,7 @@ defmodule AppWeb.BookTransfersLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <.app_page>
+    <.app_page flash={@flash}>
       <:breadcrumb>
         <.breadcrumb_item navigate={~p"/books/#{@book}"}>
           {@book.name}


### PR DESCRIPTION
## Why?

Currently, each page that wants to display alerts need to declare it explicitly. It's easy to overlook some.

## What?

Add it directly to the `<.app_page>` component, so most pages are covered by default.