### PR TITLE
chore(deploy): fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,11 @@ COPY lib lib
 COPY assets assets
 COPY .git .git
 
-# compile assets
-RUN mix assets.deploy
-
 # Compile the release
 RUN mix compile
+
+# compile assets
+RUN mix assets.deploy
 
 # Changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/


### PR DESCRIPTION
## Why?

The Dockerfile build broke with #486. Indeed, the assets now require the application to be built before, since they rely on a file generated by Phoenix compilation.

## What?

Fix the Dockerfile build by compiling assets after compiling the Elixir project.
