### PR TITLE
fix(i18n): download locales data in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ RUN mkdir config
 COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
+# Pre-download Localize's locale data so it's baked into the release
+# and doesn't need to be fetched at runtime.
+RUN mix localize.download_locales
+
 COPY priv priv
 COPY lib lib
 COPY assets assets

--- a/config/config.exs
+++ b/config/config.exs
@@ -65,7 +65,10 @@ config :phoenix, :json_library, Jason
 # Configure your application's default locale and more.
 
 config :gettext, :default_locale, "en"
-config :localize, default_locale: :en
+
+config :localize,
+  default_locale: :en,
+  supported_locales: [:en, :fr]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -170,7 +170,3 @@ if config_env() == :prod do
     secret: ses_secret_key,
     identity: ses_identity
 end
-
-## Internationalization
-
-config :localize, supported_locales: Gettext.known_locales(AppWeb.Gettext)


### PR DESCRIPTION
## Why?

Localize, introduced in #473, does not work properly in production. The locale data should be downloaded when building the Docker image for it to be available there.

## What?

Run `mix localize.download_locales` in the Dockerfile to download and cache locales data.
Move localize configuration to `config.exs`, making it available to the Mix task - otherwise, the task defaults to download _all_ data, for _all_ locales.