### PR TITLE
chore(books): remove BookMember `:role` field

### DIFF
--- a/lib/app/books.ex
+++ b/lib/app/books.ex
@@ -51,7 +51,6 @@ defmodule App.Books do
   ## Filters
 
   - `:sort_by` - the field to sort by, one of :alphabetically or :last_created
-  - `:owned_by` - the ownership of the book, one of :anyone, :me or :others
   - `:close_state` - the close state of the book, one of :any, :open or :closed
   """
   @spec list_books_of_user(User.t(), map()) :: [Book.t()]
@@ -75,7 +74,6 @@ defmodule App.Books do
 
   @filters_default %{
     sort_by: :last_created,
-    owned_by: [],
     close_state: []
   }
   @filters_types %{
@@ -83,7 +81,6 @@ defmodule App.Books do
       Ecto.ParameterizedType.init(Ecto.Enum,
         values: [:last_created, :first_created, :alphabetically]
       ),
-    owned_by: {:array, Ecto.ParameterizedType.init(Ecto.Enum, values: [:me, :others])},
     close_state: {:array, Ecto.ParameterizedType.init(Ecto.Enum, values: [:open, :closed])}
   }
 
@@ -95,7 +92,6 @@ defmodule App.Books do
 
     query
     |> sort_books_by(filters[:sort_by])
-    |> filter_books_by_ownership(filters[:owned_by])
     |> filter_books_by_close_state(filters[:close_state])
   end
 
@@ -108,15 +104,6 @@ defmodule App.Books do
 
   defp sort_books_by(query, :alphabetically),
     do: from([book: book] in query, order_by: [asc: book.name])
-
-  # filter `:owned_by`
-  defp filter_books_by_ownership(query, [:me]),
-    do: from([current_member: current_member] in query, where: current_member.role == :creator)
-
-  defp filter_books_by_ownership(query, [:others]),
-    do: from([current_member: current_member] in query, where: current_member.role != :creator)
-
-  defp filter_books_by_ownership(query, _empty_or_both), do: query
 
   # filter `:close_state`
 

--- a/lib/app/books.ex
+++ b/lib/app/books.ex
@@ -130,7 +130,6 @@ defmodule App.Books do
       |> Ecto.Multi.insert(:book, Book.name_changeset(%Book{}, attrs))
       |> Ecto.Multi.insert(:creator, fn %{book: book} ->
         member = %BookMember{
-          role: :creator,
           book_id: book.id,
           user_id: creator.id
         }

--- a/lib/app/books/book_member.ex
+++ b/lib/app/books/book_member.ex
@@ -1,7 +1,6 @@
 defmodule App.Books.BookMember do
   @moduledoc """
   The link between a book and a user.
-  It contains the role of the user for this particular book.
   """
   use Ecto.Schema
   import Ecto.Changeset
@@ -17,7 +16,6 @@ defmodule App.Books.BookMember do
           id: id(),
           book_id: Book.id(),
           book: Book.t(),
-          role: :creator | :member,
           user_id: User.id() | nil,
           user: User.t() | nil,
           deleted_at: NaiveDateTime.t() | nil,
@@ -32,7 +30,6 @@ defmodule App.Books.BookMember do
 
   schema "book_members" do
     belongs_to :book, Book
-    field :role, Ecto.Enum, values: [:creator, :member], default: :member
 
     belongs_to :user, User
 

--- a/lib/app/books/book_member.ex
+++ b/lib/app/books/book_member.ex
@@ -32,7 +32,7 @@ defmodule App.Books.BookMember do
 
   schema "book_members" do
     belongs_to :book, Book
-    field :role, Ecto.Enum, values: [:creator, :member]
+    field :role, Ecto.Enum, values: [:creator, :member], default: :member
 
     belongs_to :user, User
 

--- a/lib/app/books/members.ex
+++ b/lib/app/books/members.ex
@@ -78,8 +78,7 @@ defmodule App.Books.Members do
           {:ok, BookMember.t()} | {:error, Ecto.Changeset.t()}
   def create_book_member(%Book{} = book, attrs) do
     %BookMember{
-      book_id: book.id,
-      role: :member
+      book_id: book.id
     }
     |> BookMember.nickname_changeset(attrs)
     |> Repo.insert()
@@ -106,7 +105,6 @@ defmodule App.Books.Members do
   def create_book_member_for_user(book, user, params) do
     %BookMember{
       book_id: book.id,
-      role: :member,
       user_id: user.id
     }
     |> BookMember.nickname_changeset(params)

--- a/lib/app_web/live/books_live.ex
+++ b/lib/app_web/live/books_live.ex
@@ -36,14 +36,6 @@ defmodule AppWeb.BooksLive do
           phx-change="filters"
           filters={[
             multi_select(
-              name: "owned_by",
-              label: gettext("Owned by"),
-              options: [
-                me: gettext("Me"),
-                others: gettext("Others")
-              ]
-            ),
-            multi_select(
               name: "close_state",
               label: gettext("State"),
               options: [

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -387,10 +387,6 @@ msgid "Others"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "Owned by"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "Paid by"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -388,10 +388,6 @@ msgid "Others"
 msgstr "Others"
 
 #, elixir-autogen, elixir-format
-msgid "Owned by"
-msgstr "Owned by"
-
-#, elixir-autogen, elixir-format
 msgid "Paid by"
 msgstr "Paid by"
 

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -388,10 +388,6 @@ msgid "Others"
 msgstr "Les autres"
 
 #, elixir-autogen, elixir-format
-msgid "Owned by"
-msgstr "Appartenant à"
-
-#, elixir-autogen, elixir-format
 msgid "Paid by"
 msgstr "Payé par"
 

--- a/priv/repo/migrations/20260714103030_drop_book_member_role.exs
+++ b/priv/repo/migrations/20260714103030_drop_book_member_role.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.DropBookMemberRole do
+  use Ecto.Migration
+
+  def change do
+    alter table(:book_members) do
+      remove :role, :string, null: false
+    end
+  end
+end

--- a/test/app/books/members_test.exs
+++ b/test/app/books/members_test.exs
@@ -125,7 +125,6 @@ defmodule App.Books.MembersTest do
                Members.create_book_member_for_user(book, user, %{nickname: "Member"})
 
       assert book_member.book_id == book.id
-      assert book_member.role == :member
       assert book_member.user_id == user.id
       assert book_member.nickname == "Member"
     end
@@ -157,7 +156,7 @@ defmodule App.Books.MembersTest do
   defp book_with_creator_context(_context) do
     book = book_fixture()
     user = user_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     %{
       book: book,

--- a/test/app/books_test.exs
+++ b/test/app/books_test.exs
@@ -141,46 +141,6 @@ defmodule App.BooksTest do
              |> Enum.map(& &1.id) == [book2.id, book1.id]
     end
 
-    test "filters by owned by anyone", %{user: user} do
-      book1 = book_fixture(inserted_at: ~N[2020-01-01 00:00:00Z])
-      _member1 = book_member_fixture(book1, user_id: user.id)
-
-      book2 = book_fixture(inserted_at: ~N[2020-01-02 00:00:00Z])
-      _member2 = book_member_fixture(book2, user_id: user.id)
-
-      _not_member_of_book = book_fixture()
-
-      assert user
-             |> Books.list_books_of_user(%{owned_by: [:me, :others]})
-             |> Enum.map(& &1.id) == [book2.id, book1.id]
-    end
-
-    test "filters by owned by me", %{user: user} do
-      book1 = book_fixture()
-      _member1 = book_member_fixture(book1, user_id: user.id, role: :creator)
-      book2 = book_fixture()
-      _member2 = book_member_fixture(book2, user_id: user.id, role: :member)
-
-      _not_member_of_book = book_fixture()
-
-      assert user
-             |> Books.list_books_of_user(%{owned_by: [:me]})
-             |> Enum.map(& &1.id) == [book1.id]
-    end
-
-    test "filters by owned by others", %{user: user} do
-      book1 = book_fixture()
-      _member1 = book_member_fixture(book1, user_id: user.id, role: :creator)
-      book2 = book_fixture()
-      _member2 = book_member_fixture(book2, user_id: user.id, role: :member)
-
-      _not_member_of_book = book_fixture()
-
-      assert user
-             |> Books.list_books_of_user(%{owned_by: [:others]})
-             |> Enum.map(& &1.id) == [book2.id]
-    end
-
     test "filters closed books", %{user: user} do
       book1 = book_fixture(closed_at: nil)
       _member1 = book_member_fixture(book1, user_id: user.id)

--- a/test/app/books_test.exs
+++ b/test/app/books_test.exs
@@ -28,7 +28,7 @@ defmodule App.BooksTest do
     setup do
       book = book_fixture()
       user = user_fixture()
-      _member = book_member_fixture(book, user_id: user.id, role: :creator)
+      _member = book_member_fixture(book, user_id: user.id)
       %{book: book, user: user}
     end
 
@@ -57,7 +57,7 @@ defmodule App.BooksTest do
     setup do
       book = book_fixture()
       user = user_fixture()
-      _member = book_member_fixture(book, user_id: user.id, role: :creator)
+      _member = book_member_fixture(book, user_id: user.id)
       %{book: book, user: user}
     end
 
@@ -179,7 +179,6 @@ defmodule App.BooksTest do
       assert book.name == "A valid book name !"
 
       assert member = Members.get_membership(book, user)
-      assert member.role == :creator
       assert member.nickname == "Creator nickname"
     end
 

--- a/test/app_web/book_access_test.exs
+++ b/test/app_web/book_access_test.exs
@@ -20,7 +20,7 @@ defmodule AppWeb.BookAccessTest do
   describe "on_mount: ensure_book!" do
     test "assigns the book found in parameters", %{socket: socket, user: user} do
       book = book_fixture()
-      member = book_member_fixture(book, user_id: user.id, role: :creator)
+      member = book_member_fixture(book, user_id: user.id)
 
       {:cont, updated_socket} =
         BookAccess.on_mount(:ensure_book!, %{"book_id" => book.id}, nil, socket)

--- a/test/app_web/controllers/book_invitation/book_invitation_controller_test.exs
+++ b/test/app_web/controllers/book_invitation/book_invitation_controller_test.exs
@@ -97,7 +97,6 @@ defmodule AppWeb.BookInvitationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "You have been added to the book"
 
       book_member = Repo.get_by!(BookMember, book_id: book.id, user_id: user.id)
-      assert book_member.role == :member
       assert book_member.nickname == "New Member"
     end
 

--- a/test/app_web/live/books/book_creation_live_test.exs
+++ b/test/app_web/live/books/book_creation_live_test.exs
@@ -39,7 +39,6 @@ defmodule AppWeb.BookCreationLiveTest do
 
     member = Repo.get_by(BookMember, book_id: book.id, user_id: user.id)
     assert member.nickname == "Creator name"
-    assert member.role == :creator
   end
 
   test "shows errors from both name and nickname inputs", %{conn: conn} do

--- a/test/app_web/live/books/book_invitations_live_test.exs
+++ b/test/app_web/live/books/book_invitations_live_test.exs
@@ -20,7 +20,7 @@ defmodule AppWeb.BookInvitationsLiveTest do
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     Map.merge(context, %{
       book: book,

--- a/test/app_web/live/books/book_member_creation_live_test.exs
+++ b/test/app_web/live/books/book_member_creation_live_test.exs
@@ -29,7 +29,7 @@ defmodule AppWeb.BookMemberCreationLiveTest do
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     Map.merge(context, %{
       book: book,

--- a/test/app_web/live/books/book_members_live_test.exs
+++ b/test/app_web/live/books/book_members_live_test.exs
@@ -47,7 +47,7 @@ defmodule AppWeb.BookMembersLiveTest do
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     Map.merge(context, %{
       book: book,

--- a/test/app_web/live/books/book_transfer_form_live_test.exs
+++ b/test/app_web/live/books/book_transfer_form_live_test.exs
@@ -120,7 +120,7 @@ defmodule AppWeb.BookTransferFormLiveTest do
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     Map.merge(context, %{
       book: book,

--- a/test/app_web/live/books/book_transfers_live_test.exs
+++ b/test/app_web/live/books/book_transfers_live_test.exs
@@ -64,7 +64,7 @@ defmodule AppWeb.BookTransfersLiveTest do
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()
-    member = book_member_fixture(book, user_id: user.id, role: :creator)
+    member = book_member_fixture(book, user_id: user.id)
 
     Map.merge(context, %{
       book: book,

--- a/test/support/fixtures/books/members_fixtures.ex
+++ b/test/support/fixtures/books/members_fixtures.ex
@@ -10,7 +10,6 @@ defmodule App.Books.MembersFixtures do
 
   def book_member_attributes(attrs \\ %{}) do
     Enum.into(attrs, %{
-      role: :member,
       nickname: "Member #{System.unique_integer()}"
     })
   end


### PR DESCRIPTION
## Why?

The `:role` of a book member isn't a very useful information, it is only used to filter books in the `/books` LiveView.

## What?

Delete it.
