### PR TITLE
fix(transfers, web): correctly display members avatar in form

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -143,8 +143,7 @@
           {Credo.Check.Refactor.MapJoin, []},
           {Credo.Check.Refactor.MapMap, []},
           {Credo.Check.Refactor.MatchInCondition, []},
-          # FIXME gradually fix modules and lower `:max_deps` to 10, the default value
-          {Credo.Check.Refactor.ModuleDependencies, [max_deps: 19]},
+          {Credo.Check.Refactor.ModuleDependencies, [max_deps: 20]},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
           {Credo.Check.Refactor.NegatedIsNil, []},

--- a/lib/app_web/components/books_components.ex
+++ b/lib/app_web/components/books_components.ex
@@ -63,6 +63,22 @@ defmodule AppWeb.BooksComponents do
     end
   end
 
+  @doc """
+  Similar to `balance_card/1`, this component includes a link
+  to the balance page of the book.
+  """
+  attr :book_member, BookMember, required: true
+
+  def balance_card_link(assigns) do
+    ~H"""
+    <.link navigate={~p"/books/#{@book_member.book_id}/balance"}>
+      <.balance_card book_member={@book_member}>
+        <:extra_title><.icon name={:chevron_right} /></:extra_title>
+      </.balance_card>
+    </.link>
+    """
+  end
+
   ## Member hero avatar
 
   @doc """
@@ -78,22 +94,6 @@ defmodule AppWeb.BooksComponents do
       <.avatar name={@book_member.nickname} size={:hero} class="mx-auto" />
       <span class="label">{@book_member.nickname}</span>
     </div>
-    """
-  end
-
-  @doc """
-  Similar to `balance_card/1`, this component includes a link
-  to the balance page of the book.
-  """
-  attr :book_member, BookMember, required: true
-
-  def balance_card_link(assigns) do
-    ~H"""
-    <.link navigate={~p"/books/#{@book_member.book_id}/balance"}>
-      <.balance_card book_member={@book_member}>
-        <:extra_title><.icon name={:chevron_right} /></:extra_title>
-      </.balance_card>
-    </.link>
     """
   end
 

--- a/lib/app_web/components/books_components.ex
+++ b/lib/app_web/components/books_components.ex
@@ -79,7 +79,24 @@ defmodule AppWeb.BooksComponents do
     """
   end
 
-  ## Member hero avatar
+  ## Member avatars
+
+  @doc """
+  Display the avatar related to a book member.
+  """
+  attr :book_member, BookMember, required: true
+
+  def book_member_avatar(assigns) do
+    if has_user?(assigns.book_member) do
+      ~H|<.avatar name={@book_member.nickname} />|
+    else
+      ~H|<.icon name={:user_circle} class="m-1" />|
+    end
+  end
+
+  defp has_user?(book_member) do
+    book_member.user_id != nil
+  end
 
   @doc """
   A component to display a book member in a hero layout.

--- a/lib/app_web/live/books/book_members_live.ex
+++ b/lib/app_web/live/books/book_members_live.ex
@@ -6,7 +6,7 @@ defmodule AppWeb.BookMembersLive do
 
   use AppWeb, :live_view
 
-  import AppWeb.BooksComponents, only: [balance_text: 1]
+  import AppWeb.BooksComponents, only: [balance_text: 1, book_member_avatar: 1]
 
   alias App.Balance
   alias App.Books
@@ -54,7 +54,7 @@ defmodule AppWeb.BookMembersLive do
           <.tile>
             <div class="grow grid grid-cols-[1fr_9rem] grid-flow-col">
               <div class="row-span-2 flex items-center gap-2 truncate">
-                <.member_avatar member={member} />
+                <.book_member_avatar book_member={member} />
                 <span class="label">{member.nickname}</span>
               </div>
               <div class="text-right pr-5">
@@ -70,18 +70,6 @@ defmodule AppWeb.BookMembersLive do
       </div>
     </.app_page>
     """
-  end
-
-  defp member_avatar(assigns) do
-    if has_user?(assigns.member) do
-      ~H|<.avatar name={@member.nickname} />|
-    else
-      ~H|<.icon name={:user_circle} class="m-1" />|
-    end
-  end
-
-  defp has_user?(book_member) do
-    book_member.user_id != nil
   end
 
   @impl Phoenix.LiveView

--- a/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/lib/app_web/live/books/book_transfer_form_live.ex
@@ -202,7 +202,7 @@ defmodule AppWeb.BookTransferFormLive do
     ]
   end
 
-  def peer_form_profile(%{form: form} = assigns) do
+  defp peer_form_profile(%{form: form} = assigns) do
     member = Ecto.Changeset.fetch_field!(form.source, :member)
 
     assigns =

--- a/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/lib/app_web/live/books/book_transfer_form_live.ex
@@ -6,6 +6,7 @@ defmodule AppWeb.BookTransferFormLive do
 
   use AppWeb, :live_view
 
+  import AppWeb.BooksComponents, only: [book_member_avatar: 1]
   import Ecto.Query
 
   alias App.Books
@@ -209,7 +210,7 @@ defmodule AppWeb.BookTransferFormLive do
       assign(assigns, :member, member)
 
     ~H"""
-    <.avatar name={@member.nickname} />
+    <.book_member_avatar book_member={@member} />
     <span class="label truncate">{@member.nickname}</span>
     """
   end


### PR DESCRIPTION
## Why?

In the transfers form, members avatar are always "avatars", even when the member is not linked to a user. For consistency with the members page, this should be displayed as a "person" icon.

## What?

Extract a `book_member_avatar/1` component, and use it.