### PR TITLE
feat(books): archive book members

### DIFF
--- a/lib/app/books/book_member.ex
+++ b/lib/app/books/book_member.ex
@@ -110,6 +110,15 @@ defmodule App.Books.BookMember do
   end
 
   @doc """
+  Filters down an `%Ecto.Query{}` to only return non-archived book members.
+  """
+  @spec non_archived_query(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def non_archived_query(query) do
+    from [book_member: book_member] in query,
+      where: is_nil(book_member.archived_at)
+  end
+
+  @doc """
   Updates an `%Ecto.Query{}` to select the `:email` of book members.
   """
   @spec select_email(Ecto.Query.t()) :: Ecto.Query.t()

--- a/lib/app/books/book_member.ex
+++ b/lib/app/books/book_member.ex
@@ -19,6 +19,7 @@ defmodule App.Books.BookMember do
           user_id: User.id() | nil,
           user: User.t() | nil,
           deleted_at: NaiveDateTime.t() | nil,
+          archived_at: NaiveDateTime.t() | nil,
           nickname: String.t(),
           email: String.t(),
           balance_config_id: BalanceConfig.id() | nil,
@@ -34,6 +35,7 @@ defmodule App.Books.BookMember do
     belongs_to :user, User
 
     field :deleted_at, :naive_datetime
+    field :archived_at, :naive_datetime
 
     # When the member is not linked to a user, the display name falls back to the book
     # member's `:nickname`, set at creation
@@ -69,6 +71,23 @@ defmodule App.Books.BookMember do
   @spec change_balance_config(t(), BalanceConfig.t()) :: Ecto.Changeset.t()
   def change_balance_config(struct, %BalanceConfig{} = balance_config) do
     change(struct, balance_config_id: balance_config.id)
+  end
+
+  @doc """
+  Returns a changeset to archive a book member.
+  """
+  @spec archive_changeset(t()) :: Ecto.Changeset.t()
+  def archive_changeset(book_member) do
+    now = NaiveDateTime.utc_now(:second)
+    change(book_member, archived_at: now)
+  end
+
+  @doc """
+  Returns a changeset to unarchive a book member.
+  """
+  @spec unarchive_changeset(t()) :: Ecto.Changeset.t()
+  def unarchive_changeset(book_member) do
+    change(book_member, archived_at: nil)
   end
 
   ## Queries

--- a/lib/app/books/members.ex
+++ b/lib/app/books/members.ex
@@ -31,11 +31,22 @@ defmodule App.Books.Members do
   end
 
   @doc """
-  Lists all members of a book that are not linked to a user.
+  List members of the book that are not archived.
+  """
+  @spec list_active_book_members(Book.t()) :: [BookMember.t()]
+  def list_active_book_members(book) do
+    members_of_book_query(book)
+    |> BookMember.non_archived_query()
+    |> Repo.all()
+  end
+
+  @doc """
+  Lists all members of a book that are not linked to a user and not archived.
   """
   @spec list_unlinked_members_of_book(Book.t()) :: [BookMember.t()]
   def list_unlinked_members_of_book(book) do
     members_of_book_query(book)
+    |> BookMember.non_archived_query()
     |> where([book_member: book_member], is_nil(book_member.user_id))
     |> Repo.all()
   end
@@ -56,7 +67,10 @@ defmodule App.Books.Members do
   defp members_of_book_query(book) do
     from([book_member: book_member] in BookMember.book_query(book),
       left_join: user in assoc(book_member, :user),
-      order_by: [asc: book_member.nickname]
+      order_by: [
+        asc: not is_nil(book_member.archived_at),
+        asc: book_member.nickname
+      ]
     )
     |> BookMember.select_email()
   end

--- a/lib/app/books/members.ex
+++ b/lib/app/books/members.ex
@@ -122,4 +122,50 @@ defmodule App.Books.Members do
 
     :ok
   end
+
+  ## Archive / Unarchive
+
+  @doc """
+  Checks if a book member is archived.
+  """
+  @spec archived?(BookMember.t()) :: boolean()
+  def archived?(%BookMember{} = book_member) do
+    book_member.archived_at != nil
+  end
+
+  @doc """
+  Archives a book member.
+
+  A member can only be archived if it is not linked to a user and its
+  balance is zero.
+  """
+  @spec archive_book_member(BookMember.t()) ::
+          {:ok, BookMember.t()} | {:error, :linked_to_user} | {:error, :has_balance}
+  def archive_book_member(%BookMember{archived_at: nil} = book_member) do
+    cond do
+      book_member.user_id != nil ->
+        {:error, :linked_to_user}
+
+      not Decimal.equal?(book_member.balance, 0) ->
+        {:error, :has_balance}
+
+      true ->
+        book_member =
+          book_member
+          |> BookMember.archive_changeset()
+          |> Repo.update!()
+
+        {:ok, book_member}
+    end
+  end
+
+  @doc """
+  Unarchives a book member that was previously archived.
+  """
+  @spec unarchive_book_member(BookMember.t()) :: BookMember.t()
+  def unarchive_book_member(%BookMember{archived_at: %{}} = book_member) do
+    book_member
+    |> BookMember.unarchive_changeset()
+    |> Repo.update!()
+  end
 end

--- a/lib/app/transfers/money_transfer.ex
+++ b/lib/app/transfers/money_transfer.ex
@@ -133,8 +133,11 @@ defmodule App.Transfers.MoneyTransfer do
 
   ## Queries
 
-  # create a simple query with named binding
-  defp base_query do
+  @doc """
+  Returns an `%Ecto.Query{}` fetching all money transfers.
+  """
+  @spec base_query :: Ecto.Query.t()
+  def base_query do
     from __MODULE__, as: :money_transfer
   end
 

--- a/lib/app_web/components/books_components.ex
+++ b/lib/app_web/components/books_components.ex
@@ -7,6 +7,7 @@ defmodule AppWeb.BooksComponents do
 
   alias App.Balance
   alias App.Books.BookMember
+  alias App.Books.Members
 
   ## Balance card
 
@@ -90,7 +91,12 @@ defmodule AppWeb.BooksComponents do
     if has_user?(assigns.book_member) do
       ~H|<.avatar name={@book_member.nickname} />|
     else
-      ~H|<.icon name={:user_circle} class="m-1" />|
+      ~H"""
+      <.icon
+        name={:user_circle}
+        class={["m-1", Members.archived?(@book_member) && "grayscale opacity-50"]}
+      />
+      """
     end
   end
 

--- a/lib/app_web/live/books/book_member_live.ex
+++ b/lib/app_web/live/books/book_member_live.ex
@@ -10,6 +10,7 @@ defmodule AppWeb.BookMemberLive do
 
   alias App.Accounts
   alias App.Balance
+  alias App.Books.Members
 
   on_mount {AppWeb.BookAccess, :ensure_book!}
   on_mount {AppWeb.BookAccess, :ensure_book_member!}
@@ -57,6 +58,22 @@ defmodule AppWeb.BookMemberLive do
             {gettext("Change nickname")}
           </.card_button>
         </.link>
+        <%= if Members.archived?(@book_member) do %>
+          <.link phx-click="unarchive">
+            <.card_button icon={:archive_box_x_mark}>
+              {gettext("Unarchive")}
+            </.card_button>
+          </.link>
+        <% else %>
+          <.link
+            data-confirm={gettext("Are you sure you want to archive this member?")}
+            phx-click="archive"
+          >
+            <.card_button icon={:archive_box}>
+              {gettext("Archive")}
+            </.card_button>
+          </.link>
+        <% end %>
       </.card_grid>
     </.app_page>
     """
@@ -83,5 +100,30 @@ defmodule AppWeb.BookMemberLive do
 
       {:ok, socket}
     end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("archive", _params, socket) do
+    %{book_member: book_member} = socket.assigns
+
+    case Members.archive_book_member(book_member) do
+      {:ok, book_member} ->
+        {:noreply, assign(socket, :book_member, book_member)}
+
+      {:error, reason} ->
+        error_message =
+          case reason do
+            :linked_to_user -> gettext("The member is linked to a user and cannot be archived.")
+            :has_balance -> gettext("The member's balance must be settled before archiving.")
+          end
+
+        socket = put_flash(socket, :error, error_message)
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("unarchive", _params, socket) do
+    book_member = Members.unarchive_book_member(socket.assigns.book_member)
+    {:noreply, assign(socket, :book_member, book_member)}
   end
 end

--- a/lib/app_web/live/books/book_members_live.ex
+++ b/lib/app_web/live/books/book_members_live.ex
@@ -55,7 +55,12 @@ defmodule AppWeb.BookMembersLive do
             <div class="grow grid grid-cols-[1fr_9rem] grid-flow-col">
               <div class="row-span-2 flex items-center gap-2 truncate">
                 <.book_member_avatar book_member={member} />
-                <span class="label">{member.nickname}</span>
+                <span class={["label", Members.archived?(member) && "text-gray-500"]}>
+                  {member.nickname}
+                  <span :if={Members.archived?(member)}>
+                    {gettext("(Archived)")}
+                  </span>
+                </span>
               </div>
               <div class="text-right pr-5">
                 <.balance_text book_member={member} />

--- a/lib/app_web/live/books/book_reimbursement_creation_live.ex
+++ b/lib/app_web/live/books/book_reimbursement_creation_live.ex
@@ -67,7 +67,7 @@ defmodule AppWeb.BookReimbursementCreationLive do
   def mount(params, _session, socket) do
     book = socket.assigns.book
 
-    members = Members.list_members_of_book(book)
+    members = Members.list_active_book_members(book)
     form = parse_params_form(params, members)
 
     socket =

--- a/lib/app_web/live/books/book_transfer_form_live.ex
+++ b/lib/app_web/live/books/book_transfer_form_live.ex
@@ -211,7 +211,7 @@ defmodule AppWeb.BookTransferFormLive do
 
     ~H"""
     <.book_member_avatar book_member={@member} />
-    <span class="label truncate">{@member.nickname}</span>
+    <span class={["label truncate", Members.archived?(@member) && "text-gray-500"]}>{@member.nickname}</span>
     """
   end
 
@@ -245,24 +245,21 @@ defmodule AppWeb.BookTransferFormLive do
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
-    %{book: book, live_action: live_action} = socket.assigns
-    members = Members.list_members_of_book(book)
+    %{live_action: live_action} = socket.assigns
 
-    socket =
-      socket
-      |> assign(members: members)
-      |> mount_action(live_action, params)
-
+    socket = mount_action(socket, live_action, params)
     {:ok, socket}
   end
 
   defp mount_action(socket, :new, params) do
-    %{book: book, current_member: current_member, members: members} = socket.assigns
-    type = parse_params_type(params["type"])
+    %{book: book, current_member: current_member} = socket.assigns
 
     if Books.closed?(book) do
       push_navigate(socket, to: ~p"/books/#{book}")
     else
+      type = parse_params_type(params["type"])
+      members = Members.list_active_book_members(book)
+
       peers =
         for member <- members do
           %Peer{member_id: member.id, member: member}
@@ -280,6 +277,7 @@ defmodule AppWeb.BookTransferFormLive do
 
       assign(socket,
         page_title: form_new_title(type),
+        members: members,
         form: form,
         type: type,
         display_weight?: false
@@ -288,7 +286,9 @@ defmodule AppWeb.BookTransferFormLive do
   end
 
   defp mount_action(socket, :edit, %{"money_transfer_id" => money_transfer_id}) do
-    money_transfer = get_money_transfer(money_transfer_id, socket)
+    %{book: book} = socket.assigns
+    members = list_money_transfer_members(book, money_transfer_id)
+    money_transfer = get_money_transfer(book, members, money_transfer_id)
 
     form =
       money_transfer
@@ -299,11 +299,39 @@ defmodule AppWeb.BookTransferFormLive do
 
     assign(socket,
       page_title: money_transfer.label,
+      members: members,
       form: form,
       type: money_transfer.type,
       display_weight?: display_weight?,
       money_transfer: money_transfer
     )
+  end
+
+  # Include members of the book that match any of these conditions:
+  # - they are not archived
+  # - they are the tenant of the current money transfer
+  # - they are a peer of current money transfer
+  #
+  # The idea is to let archived member be displayed as usual if they
+  # are already part of the money transfer.
+  defp list_money_transfer_members(book, money_transfer_id) do
+    query =
+      from book_member in BookMember.book_query(book),
+        where:
+          is_nil(book_member.archived_at) or
+            exists(
+              from money_transfer in MoneyTransfer.base_query(),
+                where: money_transfer.id == ^money_transfer_id,
+                where: money_transfer.tenant_id == parent_as(:book_member).id
+            ) or
+            exists(
+              from peer in Peer.base_query(),
+                where: peer.transfer_id == ^money_transfer_id,
+                where: peer.member_id == parent_as(:book_member).id
+            ),
+        order_by: [asc: book_member.nickname]
+
+    Repo.all(query)
   end
 
   defp form_new_title(:income), do: gettext("New income")
@@ -312,8 +340,7 @@ defmodule AppWeb.BookTransferFormLive do
   defp parse_params_type("income"), do: :income
   defp parse_params_type(_payment_or_nil), do: :payment
 
-  defp get_money_transfer(money_transfer_id, socket) do
-    %{book: book, members: members} = socket.assigns
+  defp get_money_transfer(book, members, money_transfer_id) do
     members_by_id = Map.new(members, &{&1.id, &1})
 
     from([money_transfer: money_transfer] in MoneyTransfer.transfers_of_book_query(book),

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -19,6 +19,10 @@ msgid "%{count} unlinked"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "(Archived)"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
 
@@ -44,6 +48,14 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Anacounts is a free and open-source software that helps you share expensenses for a trip with your friend or in your household in a more fair way."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Archive"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to archive this member?"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -512,6 +524,14 @@ msgid "The main difference with invited members is that you can see and edit rev
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "The member is linked to a user and cannot be archived."
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "The member's balance must be settled before archiving."
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "There is no transfer in the book for now. You can finish the operation safely!"
 msgstr ""
 
@@ -553,6 +573,10 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "Type your new password again here"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "Unarchive"
 msgstr ""
 
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -20,6 +20,10 @@ msgid "%{count} unlinked"
 msgstr "%{count} unlinked"
 
 #, elixir-autogen, elixir-format
+msgid "(Archived)"
+msgstr "(Archived)"
+
+#, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "A link to confirm your email change has been sent to the new address."
 
@@ -46,6 +50,14 @@ msgstr "Amount"
 #, elixir-autogen, elixir-format
 msgid "Anacounts is a free and open-source software that helps you share expensenses for a trip with your friend or in your household in a more fair way."
 msgstr "Anacounts is a free and open-source software that helps you share expensenses for a trip with your friend or in your household in a more fair way."
+
+#, elixir-autogen, elixir-format
+msgid "Archive"
+msgstr "Archive"
+
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to archive this member?"
+msgstr "Are you sure you want to archive this member?"
 
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete the transfer?"
@@ -513,6 +525,14 @@ msgid "The main difference with invited members is that you can see and edit rev
 msgstr "The main difference with invited members is that you can see and edit revenues of unlinked members from their member page."
 
 #, elixir-autogen, elixir-format
+msgid "The member is linked to a user and cannot be archived."
+msgstr "The member is linked to a user and cannot be archived."
+
+#, elixir-autogen, elixir-format
+msgid "The member's balance must be settled before archiving."
+msgstr "The member's balance must be settled before archiving."
+
+#, elixir-autogen, elixir-format
 msgid "There is no transfer in the book for now. You can finish the operation safely!"
 msgstr "There is no transfer in the book for now. You can finish the operation safely!"
 
@@ -555,6 +575,10 @@ msgstr "Transfers"
 #, elixir-autogen, elixir-format
 msgid "Type your new password again here"
 msgstr "Type your new password again here"
+
+#, elixir-autogen, elixir-format
+msgid "Unarchive"
+msgstr "Unarchive"
 
 #, elixir-autogen, elixir-format
 msgid "View profile"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -20,6 +20,10 @@ msgid "%{count} unlinked"
 msgstr "%{count} sans utilisateur"
 
 #, elixir-autogen, elixir-format
+msgid "(Archived)"
+msgstr "(Archivé)"
+
+#, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Un lien de confirmation a été envoyé à votre nouvelle adresse."
 
@@ -46,6 +50,14 @@ msgstr "Montant"
 #, elixir-autogen, elixir-format
 msgid "Anacounts is a free and open-source software that helps you share expensenses for a trip with your friend or in your household in a more fair way."
 msgstr "Anacounts est un logiciel gratuit et open source aidant à rendre la répartition des dépenses de vos voyages ou de votre foyer plus juste."
+
+#, elixir-autogen, elixir-format
+msgid "Archive"
+msgstr "Archiver"
+
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to archive this member?"
+msgstr "Êtes-vous certain de vouloir archiver ce membre ?"
 
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete the transfer?"
@@ -513,6 +525,14 @@ msgid "The main difference with invited members is that you can see and edit rev
 msgstr "La différence principale avec les membres invités est que vous pouvez voir et modifier les revenues des membres sans utilisateurs."
 
 #, elixir-autogen, elixir-format
+msgid "The member is linked to a user and cannot be archived."
+msgstr "Le member est lié à un utilisateur et ne peut pas être archivé."
+
+#, elixir-autogen, elixir-format
+msgid "The member's balance must be settled before archiving."
+msgstr "Le solde de ce membre doit être à zéro avec de l'archiver."
+
+#, elixir-autogen, elixir-format
 msgid "There is no transfer in the book for now. You can finish the operation safely!"
 msgstr "Il n'y a pas de transfert dans le livret pour le moment. Vous pouvez terminer l'opération !"
 
@@ -555,6 +575,10 @@ msgstr "Transferts"
 #, elixir-autogen, elixir-format
 msgid "Type your new password again here"
 msgstr "Taper votre nouveau mot de passe encore une fois ici"
+
+#, elixir-autogen, elixir-format
+msgid "Unarchive"
+msgstr "Désarchiver"
 
 #, elixir-autogen, elixir-format
 msgid "View profile"

--- a/priv/repo/migrations/20260718122708_add_book_member_archived_at.exs
+++ b/priv/repo/migrations/20260718122708_add_book_member_archived_at.exs
@@ -1,0 +1,13 @@
+defmodule App.Repo.Migrations.AddBookMemberArchivedAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:book_members) do
+      add :archived_at, :naive_datetime
+    end
+
+    create constraint(:book_members, :archived_at_null_if_user_id_null,
+             check: "archived_at IS NULL OR user_id IS NULL"
+           )
+  end
+end

--- a/test/app/books/members_test.exs
+++ b/test/app/books/members_test.exs
@@ -153,6 +153,56 @@ defmodule App.Books.MembersTest do
     end
   end
 
+  describe "archived?/1" do
+    test "returns true if the member is archived" do
+      book_member =
+        book_member_fixture(book_fixture(), archived_at: NaiveDateTime.utc_now(:second))
+
+      assert Members.archived?(book_member)
+    end
+
+    test "returns false if the member is not archived" do
+      book_member = book_member_fixture(book_fixture())
+      refute Members.archived?(book_member)
+    end
+  end
+
+  describe "archive_book_member/2" do
+    test "archives a member with a zero balance and no linked user" do
+      book_member = book_member_fixture(book_fixture(), user_id: nil)
+      book_member = %{book_member | balance: Decimal.new(0)}
+
+      assert {:ok, book_member} = Members.archive_book_member(book_member)
+      assert Members.archived?(book_member)
+    end
+
+    test "returns an error if the member has a non-zero balance" do
+      book_member = book_member_fixture(book_fixture(), user_id: nil)
+      book_member = %{book_member | balance: Decimal.new(1)}
+
+      assert {:error, :has_balance} = Members.archive_book_member(book_member)
+      refute Members.archived?(Repo.reload(book_member))
+    end
+
+    test "returns an error if the member is linked to a user" do
+      book_member = book_member_fixture(book_fixture(), user_id: user_fixture().id)
+      book_member = %{book_member | balance: Decimal.new(0)}
+
+      assert {:error, :linked_to_user} = Members.archive_book_member(book_member)
+      refute Members.archived?(Repo.reload(book_member))
+    end
+  end
+
+  describe "unarchive_book_member/1" do
+    test "unarchives an archived member" do
+      book_member =
+        book_member_fixture(book_fixture(), archived_at: NaiveDateTime.utc_now(:second))
+
+      book_member = Members.unarchive_book_member(book_member)
+      refute Members.archived?(book_member)
+    end
+  end
+
   defp book_with_creator_context(_context) do
     book = book_fixture()
     user = user_fixture()

--- a/test/app/books/members_test.exs
+++ b/test/app/books/members_test.exs
@@ -19,6 +19,47 @@ defmodule App.Books.MembersTest do
              |> Enum.map(& &1.id)
              |> Enum.sort() == [linked_member.id, unlinked_member.id]
     end
+
+    test "lists archived members after active members, alphabetically within each group" do
+      book = book_fixture()
+
+      active_b = book_member_fixture(book, nickname: "B")
+      active_a = book_member_fixture(book, nickname: "A")
+
+      archived_b =
+        book_member_fixture(book, nickname: "B", archived_at: NaiveDateTime.utc_now(:second))
+
+      archived_a =
+        book_member_fixture(book, nickname: "A", archived_at: NaiveDateTime.utc_now(:second))
+
+      assert book
+             |> Members.list_members_of_book()
+             |> Enum.map(& &1.id) == [active_a.id, active_b.id, archived_a.id, archived_b.id]
+    end
+  end
+
+  describe "list_active_book_members/1" do
+    test "lists members of the book that are not archived" do
+      book = book_fixture()
+      active_member = book_member_fixture(book)
+      _other_member = book_member_fixture(book_fixture())
+
+      assert book
+             |> Members.list_active_book_members()
+             |> Enum.map(& &1.id) == [active_member.id]
+    end
+
+    test "excludes archived members" do
+      book = book_fixture()
+      active_member = book_member_fixture(book)
+
+      _archived_member =
+        book_member_fixture(book, archived_at: NaiveDateTime.utc_now(:second))
+
+      assert book
+             |> Members.list_active_book_members()
+             |> Enum.map(& &1.id) == [active_member.id]
+    end
   end
 
   describe "list_unlinked_members_of_book/1" do
@@ -27,6 +68,18 @@ defmodule App.Books.MembersTest do
       _linked_member = book_member_fixture(book, user_id: user_fixture().id)
       unlinked_member = book_member_fixture(book, user_id: nil)
       _other_member = book_member_fixture(book_fixture())
+
+      assert book
+             |> Members.list_unlinked_members_of_book()
+             |> Enum.map(& &1.id) == [unlinked_member.id]
+    end
+
+    test "excludes archived members" do
+      book = book_fixture()
+      unlinked_member = book_member_fixture(book, user_id: nil)
+
+      _archived_member =
+        book_member_fixture(book, user_id: nil, archived_at: NaiveDateTime.utc_now(:second))
 
       assert book
              |> Members.list_unlinked_members_of_book()

--- a/test/app_web/live/books/book_member_live_test.exs
+++ b/test/app_web/live/books/book_member_live_test.exs
@@ -73,4 +73,69 @@ defmodule AppWeb.BookMemberLiveTest do
     assert {:error, {:live_redirect, %{to: ^redirected_to}}} =
              live(conn, ~p"/books/#{book}/members/#{member}")
   end
+
+  describe "archive" do
+    test "archives a member with a zero balance and no linked user", %{conn: conn, book: book} do
+      member = book_member_fixture(book, user_id: nil)
+
+      {:ok, live, _html} = live(conn, ~p"/books/#{book}/members/#{member}")
+
+      html = live |> element("[phx-click='archive']") |> render_click()
+
+      assert html =~ "Unarchive"
+      refute html =~ "Archive"
+    end
+
+    test "shows an error and does not archive a member with a non-zero balance",
+         %{
+           conn: conn,
+           book: book
+         } do
+      member = book_member_fixture(book, user_id: nil)
+      other_member = book_member_fixture(book, user_id: nil)
+
+      transfer = money_transfer_fixture(book, amount: Decimal.new(2), tenant_id: other_member.id)
+      _peer1 = peer_fixture(transfer, member_id: member.id)
+      _peer2 = peer_fixture(transfer, member_id: other_member.id)
+
+      {:ok, live, _html} = live(conn, ~p"/books/#{book}/members/#{member}")
+
+      html = live |> element("[phx-click='archive']") |> render_click()
+
+      assert html =~ "The member&#39;s balance must be settled before archiving."
+      assert html =~ "Archive"
+      refute html =~ "Unarchive"
+    end
+
+    test "shows an error and does not archive a member linked to a user",
+         %{
+           conn: conn,
+           book: book
+         } do
+      user = user_fixture()
+      member = book_member_fixture(book, user_id: user.id)
+
+      {:ok, live, _html} = live(conn, ~p"/books/#{book}/members/#{member}")
+
+      html = live |> element("[phx-click='archive']") |> render_click()
+
+      assert html =~ "The member is linked to a user and cannot be archived."
+      assert html =~ "Archive"
+      refute html =~ "Unarchive"
+    end
+  end
+
+  describe "unarchive" do
+    test "unarchives an archived member", %{conn: conn, book: book} do
+      member =
+        book_member_fixture(book, user_id: nil, archived_at: NaiveDateTime.utc_now(:second))
+
+      {:ok, live, _html} = live(conn, ~p"/books/#{book}/members/#{member}")
+
+      html = live |> element("[phx-click='unarchive']") |> render_click()
+
+      assert html =~ "Archive"
+      refute html =~ "Unarchive"
+    end
+  end
 end

--- a/test/app_web/live/books/book_members_live_test.exs
+++ b/test/app_web/live/books/book_members_live_test.exs
@@ -29,6 +29,22 @@ defmodule AppWeb.BookMembersLiveTest do
     refute html =~ "Eric"
   end
 
+  test "displays archived members last, greyed and labelled", %{conn: conn, book: book} do
+    archived_member =
+      book_member_fixture(book, nickname: "Archie", archived_at: NaiveDateTime.utc_now(:second))
+
+    active_member = book_member_fixture(book, nickname: "Zach")
+
+    {:ok, _live, html} = live(conn, ~p"/books/#{book}/members")
+
+    assert html =~ "(Archived)"
+    assert html =~ "grayscale opacity-50"
+
+    active_index = :binary.match(html, active_member.nickname) |> elem(0)
+    archived_index = :binary.match(html, archived_member.nickname) |> elem(0)
+    assert active_index < archived_index
+  end
+
   test "tiles navigate to the member page", %{conn: conn, book: book} do
     member = book_member_fixture(book)
 

--- a/test/app_web/live/books/book_reimbursement_creation_live_test.exs
+++ b/test/app_web/live/books/book_reimbursement_creation_live_test.exs
@@ -25,6 +25,15 @@ defmodule AppWeb.BookReimbursementCreationLiveTest do
     assert html =~ "Create reimbursement"
   end
 
+  test "does not propose archived members", %{conn: conn, book: book} do
+    _archived_member =
+      book_member_fixture(book, nickname: "Archie", archived_at: NaiveDateTime.utc_now(:second))
+
+    {:ok, _live, html} = live(conn, ~p"/books/#{book}/reimbursements/new")
+
+    refute html =~ "Archie"
+  end
+
   test "includes params as default values", %{conn: conn, book: book} do
     member1 = book_member_fixture(book, nickname: "Member 1")
     member2 = book_member_fixture(book, nickname: "Member 2")

--- a/test/app_web/live/books/book_transfer_form_live_test.exs
+++ b/test/app_web/live/books/book_transfer_form_live_test.exs
@@ -117,6 +117,51 @@ defmodule AppWeb.BookTransferFormLiveTest do
     assert [peer.id] == new_peer_ids
   end
 
+  describe "archived members" do
+    test "are not proposed as peers or tenant on a new transfer", %{conn: conn, book: book} do
+      _archived_member =
+        book_member_fixture(book, nickname: "Archie", archived_at: NaiveDateTime.utc_now(:second))
+
+      {:ok, _form_live, html} = live(conn, ~p"/books/#{book}/transfers/new")
+
+      refute html =~ "Archie"
+    end
+
+    test "still show up as an already-selected peer when editing a transfer",
+         %{
+           conn: conn,
+           book: book
+         } do
+      tenant = book_member_fixture(book)
+
+      archived_member =
+        book_member_fixture(book, nickname: "Archie", archived_at: NaiveDateTime.utc_now(:second))
+
+      money_transfer = money_transfer_fixture(book, tenant_id: tenant.id)
+      _peer = peer_fixture(money_transfer, member_id: archived_member.id)
+
+      {:ok, _form_live, html} = live(conn, ~p"/books/#{book}/transfers/#{money_transfer}/edit")
+
+      assert html =~ "Archie"
+      assert html =~ "grayscale opacity-50"
+    end
+
+    test "still show up as the current tenant when editing a transfer",
+         %{
+           conn: conn,
+           book: book
+         } do
+      archived_member =
+        book_member_fixture(book, nickname: "Archie", archived_at: NaiveDateTime.utc_now(:second))
+
+      money_transfer = money_transfer_fixture(book, tenant_id: archived_member.id)
+
+      {:ok, _form_live, html} = live(conn, ~p"/books/#{book}/transfers/#{money_transfer}/edit")
+
+      assert html =~ ~s(selected="" value="#{archived_member.id}">Archie)
+    end
+  end
+
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()


### PR DESCRIPTION
## Why?

Currently, once book members are created, they are always going to be displayed in all lists. This is bothersome for long running books, where members can come and go.

## What?

This PR aims to allow archiving book members.

**Conditions:**
Only members not linked to a user and with a balance of 0 can be archived. The "archived" status can be undone at any time.

**What the "archived" status changes:**
Archived members:
- are displayed after active members, greyed out, in the "members" interface
- cannot be "joined as" through the invitation page
- are not proposed as peer for new transfers (but are still displayed in transfers where they are already tenant and/or peer)
- are not proposed for reimbursements