### PR TITLE
chore(members): remove book members `:deleted_at` field

### DIFF
--- a/lib/app/books/book_member.ex
+++ b/lib/app/books/book_member.ex
@@ -18,7 +18,6 @@ defmodule App.Books.BookMember do
           book: Book.t(),
           user_id: User.id() | nil,
           user: User.t() | nil,
-          deleted_at: NaiveDateTime.t() | nil,
           archived_at: NaiveDateTime.t() | nil,
           nickname: String.t(),
           email: String.t(),
@@ -34,7 +33,6 @@ defmodule App.Books.BookMember do
 
     belongs_to :user, User
 
-    field :deleted_at, :naive_datetime
     field :archived_at, :naive_datetime
 
     # When the member is not linked to a user, the display name falls back to the book

--- a/priv/repo/migrations/20260718142248_drop_book_member_deleted_at.exs
+++ b/priv/repo/migrations/20260718142248_drop_book_member_deleted_at.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.DropBookMemberDeletedAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:book_members) do
+      remove :deleted_at, :naive_datetime
+    end
+  end
+end


### PR DESCRIPTION
## Why?

The field is not used any where, and there is no plan to do so either.

## What?

Drop it.
