### PR TITLE
fix(books, web): do not count archived members in summary

### DIFF
--- a/lib/app_web/live/books/book_live.ex
+++ b/lib/app_web/live/books/book_live.ex
@@ -98,13 +98,19 @@ defmodule AppWeb.BookLive do
   end
 
   defp members_count(book) do
-    from([book_member: book_member] in BookMember.book_query(book),
-      select: %{
-        total: count(),
-        unlinked: fragment("? FILTER (WHERE ?)", count(), is_nil(book_member.user_id))
-      }
-    )
-    |> Repo.one!()
+    base_query =
+      book
+      |> BookMember.book_query()
+      |> BookMember.non_archived_query()
+
+    count_query =
+      from book_member in base_query,
+        select: %{
+          total: count(),
+          unlinked: filter(count(), is_nil(book_member.user_id))
+        }
+
+    Repo.one!(count_query)
   end
 
   defp latest_transfers(book) do

--- a/test/app_web/live/books/book_live_test.exs
+++ b/test/app_web/live/books/book_live_test.exs
@@ -148,14 +148,21 @@ defmodule AppWeb.BookLiveTest do
 
       {:ok, _live, html} = live(conn, ~p"/books/#{book}")
 
-      member_card_text =
-        html
-        |> LazyHTML.from_fragment()
-        |> LazyHTML.query("[href='/books/#{book.id}/members']")
-        |> LazyHTML.text()
+      assert member_card_lines(html, book) == ["Members", "3", "2 unlinked"]
+    end
 
-      assert member_card_text =~ "3"
-      assert member_card_text =~ "2 unlinked"
+    test "excludes archived members from the count", %{conn: conn, book: book} do
+      _member2 = book_member_fixture(book, nickname: "Member2")
+
+      _archived_member =
+        book_member_fixture(book,
+          nickname: "NotCounted",
+          archived_at: NaiveDateTime.utc_now(:second)
+        )
+
+      {:ok, _live, html} = live(conn, ~p"/books/#{book}")
+
+      assert member_card_lines(html, book) == ["Members", "2", "1 unlinked"]
     end
 
     test "navigates to the book members", %{conn: conn, book: book} do
@@ -168,6 +175,20 @@ defmodule AppWeb.BookLiveTest do
                |> follow_redirect(conn, ~p"/books/#{book}/members")
 
       assert html =~ "Members"
+    end
+
+    defp member_card_lines(html, book) do
+      member_card_text =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query("[href='/books/#{book.id}/members']")
+        |> LazyHTML.text()
+
+      for line <- String.split(member_card_text, "\n"),
+          trimmed_line = String.trim(line),
+          trimmed_line != "" do
+        trimmed_line
+      end
     end
   end
 


### PR DESCRIPTION
## Why?

The archived members (introduced in #502) are still counted in the member count summary in the book page.

## What?

Exclude them from the count.
