### PR TITLE
fix(transfers): do not include archived members in filter

### DIFF
--- a/lib/app_web/live/books/book_transfers_live.ex
+++ b/lib/app_web/live/books/book_transfers_live.ex
@@ -219,10 +219,11 @@ defmodule AppWeb.BookTransfersLive do
     book = socket.assigns.book
 
     book_members_options =
-      from(book_member in BookMember.book_query(book),
-        order_by: [asc: book_member.nickname],
-        select: {book_member.id, book_member.nickname}
-      )
+      book
+      |> BookMember.book_query()
+      |> BookMember.non_archived_query()
+      |> order_by(asc: :nickname)
+      |> select([book_member], {book_member.id, book_member.nickname})
       |> Repo.all()
 
     assign(socket, :book_members_options, book_members_options)

--- a/test/app_web/live/books/book_transfers_live_test.exs
+++ b/test/app_web/live/books/book_transfers_live_test.exs
@@ -8,57 +8,59 @@ defmodule AppWeb.BookTransfersLiveTest do
 
   setup [:register_and_log_in_user, :book_with_member_context]
 
-  test "lists book money transfers", %{conn: conn, book: book, member: member} do
-    money_transfer = money_transfer_fixture(book, tenant_id: member.id)
+  describe "Transfers list" do
+    test "lists book money transfers", %{conn: conn, book: book, member: member} do
+      money_transfer = money_transfer_fixture(book, tenant_id: member.id)
 
-    other_book = book_fixture()
+      other_book = book_fixture()
 
-    other_money_transfer =
-      money_transfer_fixture(other_book,
-        tenant_id: member.id,
-        label: "Other book money transfer"
-      )
+      other_money_transfer =
+        money_transfer_fixture(other_book,
+          tenant_id: member.id,
+          label: "Other book money transfer"
+        )
 
-    {:ok, _index_live, html} = live(conn, ~p"/books/#{book}/transfers")
+      {:ok, _index_live, html} = live(conn, ~p"/books/#{book}/transfers")
 
-    assert html =~ "Transfers"
-    assert html =~ money_transfer.label
-    refute html =~ other_money_transfer.label
-  end
+      assert html =~ "Transfers"
+      assert html =~ money_transfer.label
+      refute html =~ other_money_transfer.label
+    end
 
-  test "allows to go to edit form", %{conn: conn, book: book, member: member} do
-    money_transfer = money_transfer_fixture(book, tenant_id: member.id)
+    test "allows to go to edit form", %{conn: conn, book: book, member: member} do
+      money_transfer = money_transfer_fixture(book, tenant_id: member.id)
 
-    {:ok, index_live, html} = live(conn, ~p"/books/#{book}/transfers")
+      {:ok, index_live, html} = live(conn, ~p"/books/#{book}/transfers")
 
-    assert html =~ "Transfers"
-    assert html =~ money_transfer.label
+      assert html =~ "Transfers"
+      assert html =~ money_transfer.label
 
-    {:ok, _edit_live, html} =
-      index_live
-      |> element(".button", "Edit")
-      |> render_click()
-      |> follow_redirect(conn, ~p"/books/#{book}/transfers/#{money_transfer}/edit")
+      {:ok, _edit_live, html} =
+        index_live
+        |> element(".button", "Edit")
+        |> render_click()
+        |> follow_redirect(conn, ~p"/books/#{book}/transfers/#{money_transfer}/edit")
 
-    assert html =~ "Save"
-    assert html =~ "<form"
-    assert html =~ money_transfer.label
-  end
+      assert html =~ "Save"
+      assert html =~ "<form"
+      assert html =~ money_transfer.label
+    end
 
-  test "allows to delete a transfer", %{conn: conn, book: book, member: member} do
-    money_transfer = money_transfer_fixture(book, tenant_id: member.id)
+    test "allows to delete a transfer", %{conn: conn, book: book, member: member} do
+      money_transfer = money_transfer_fixture(book, tenant_id: member.id)
 
-    {:ok, index_live, html} = live(conn, ~p"/books/#{book}/transfers")
+      {:ok, index_live, html} = live(conn, ~p"/books/#{book}/transfers")
 
-    assert html =~ "Transfers"
-    assert html =~ money_transfer.label
+      assert html =~ "Transfers"
+      assert html =~ money_transfer.label
 
-    html =
-      index_live
-      |> element(".button", "Delete")
-      |> render_click()
+      html =
+        index_live
+        |> element(".button", "Delete")
+        |> render_click()
 
-    refute html =~ money_transfer.label
+      refute html =~ money_transfer.label
+    end
   end
 
   # Depends on :register_and_log_in_user

--- a/test/app_web/live/books/book_transfers_live_test.exs
+++ b/test/app_web/live/books/book_transfers_live_test.exs
@@ -63,6 +63,20 @@ defmodule AppWeb.BookTransfersLiveTest do
     end
   end
 
+  describe "List filters" do
+    test "does not list archived members in the created by filter", %{conn: conn, book: book} do
+      archived_member =
+        book_member_fixture(book,
+          nickname: "Archived member",
+          archived_at: NaiveDateTime.utc_now(:second)
+        )
+
+      {:ok, _index_live, html} = live(conn, ~p"/books/#{book}/transfers")
+
+      refute html =~ archived_member.nickname
+    end
+  end
+
   # Depends on :register_and_log_in_user
   defp book_with_member_context(%{user: user} = context) do
     book = book_fixture()


### PR DESCRIPTION
## Why?

The archived members (introduced in #502) are still displayed in the money transfers list.

## What?

Exclude them from transfers filters.
