### PR TITLE
chore(books): stop soft-deleting books

### DIFF
--- a/lib/app/books.ex
+++ b/lib/app/books.ex
@@ -164,9 +164,7 @@ defmodule App.Books do
   """
   @spec delete_book!(Book.t()) :: Book.t()
   def delete_book!(%Book{} = book) do
-    book
-    |> Book.delete_changeset()
-    |> Repo.update!()
+    Repo.delete!(book)
   end
 
   ## Close / Reopen

--- a/lib/app/books/book.ex
+++ b/lib/app/books/book.ex
@@ -12,7 +12,6 @@ defmodule App.Books.Book do
           id: id(),
           name: String.t(),
           closed_at: NaiveDateTime.t() | nil,
-          deleted_at: NaiveDateTime.t() | nil,
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }
@@ -20,7 +19,6 @@ defmodule App.Books.Book do
   schema "books" do
     field :name, :string
     field :closed_at, :naive_datetime
-    field :deleted_at, :naive_datetime
 
     timestamps()
   end
@@ -56,21 +54,11 @@ defmodule App.Books.Book do
     change(book, closed_at: nil)
   end
 
-  @doc """
-  Returns a changeset to soft-delete a book.
-  """
-  @spec delete_changeset(t()) :: Ecto.Changeset.t()
-  def delete_changeset(book) do
-    now = NaiveDateTime.utc_now(:second)
-    change(book, deleted_at: now)
-  end
-
   ## Queries
 
   @spec base_query() :: Ecto.Query.t()
   def base_query do
     from book in __MODULE__,
-      as: :book,
-      where: is_nil(book.deleted_at)
+      as: :book
   end
 end

--- a/priv/repo/data_migrations/20260719173653_delete_soft_deleted_books.exs
+++ b/priv/repo/data_migrations/20260719173653_delete_soft_deleted_books.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.DeleteSoftDeletedBooks do
+  use Ecto.Migration
+
+  def up do
+    execute "DELETE FROM books WHERE deleted_at IS NOT NULL", ""
+  end
+
+  def down, do: :ok
+end

--- a/test/app/books_test.exs
+++ b/test/app/books_test.exs
@@ -232,9 +232,7 @@ defmodule App.BooksTest do
     test "deletes the book", %{book: book} do
       deleted = Books.delete_book!(book)
       assert deleted.id == book.id
-
-      assert deleted_book = Repo.get(Book, book.id)
-      assert deleted_book.deleted_at
+      assert Repo.reload(book) == nil
     end
   end
 

--- a/test/app_web/live/books/book_creation_live_test.exs
+++ b/test/app_web/live/books/book_creation_live_test.exs
@@ -35,7 +35,6 @@ defmodule AppWeb.BookCreationLiveTest do
 
     assert book = Repo.get_by(Book, name: "Book name")
     assert book.closed_at == nil
-    assert book.deleted_at == nil
 
     member = Repo.get_by(BookMember, book_id: book.id, user_id: user.id)
     assert member.nickname == "Creator name"


### PR DESCRIPTION
## Why?

Soft-deletion can be useful to debug things... In the case of a
self-hosted application, I consider it more hurtful to the user privacy
than it can help.

## What?

Stop soft-deleting books, and add a data migration to delete already soft-deleted books.
