### PR TITLE
chore(books, repo): drop `books.deleted_at` column

### DIFF
--- a/priv/repo/migrations/20260719173334_drop_books_deleted_at.exs
+++ b/priv/repo/migrations/20260719173334_drop_books_deleted_at.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.DropBooksDeletedAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:books) do
+      remove :deleted_at, :naive_datetime
+    end
+  end
+end


### PR DESCRIPTION
## Why?

Once #510 has been deployed and the data migration ran, we can safely delete the `books.deleted_at` column.

## What?

Delete the column.
