### PR TITLE
fix(filters): add `max-height` to dropdown

### DIFF
--- a/assets/css/components/dropdown.css
+++ b/assets/css/components/dropdown.css
@@ -3,6 +3,7 @@
     @apply absolute inset-0
              p-2 m-0
              w-[20rem]
+             max-h-[20rem]
              rounded-container
              shadow;
   }


### PR DESCRIPTION
## Why?

When there are too many entries in the dropdown, it can be higher than the screen, and force scrolling the whole screen.

## What?

Limit dropdown's height to avoid such issues.
