### PR TITLE
chore(transfers): backfill `money_transfers.creator_id`

### DIFF
--- a/priv/repo/data_migrations/20260719181217_backfill_transfers_creator_id.exs
+++ b/priv/repo/data_migrations/20260719181217_backfill_transfers_creator_id.exs
@@ -1,0 +1,11 @@
+defmodule App.Repo.Migrations.BackfillTransfersCreatorID do
+  use Ecto.Migration
+
+  def up do
+    # Since the creator information is not available, consider the tenant as the creator
+    execute "UPDATE money_transfers SET creator_id = tenant_id WHERE creator_id IS NULL",
+            ""
+  end
+
+  def down, do: :ok
+end


### PR DESCRIPTION
## Why?

First step to strengthening the foreign keys in the `books` table and related.

## What?

Backfill the `money_transfers.creator_id` to make it `NOT NULL` soon.
