### PR TITLE
fix(transfers): add creator to reimbursments

### DIFF
--- a/lib/app/transfers.ex
+++ b/lib/app/transfers.ex
@@ -213,11 +213,12 @@ defmodule App.Transfers do
   @doc """
   Creates a new reimbursement.
   """
-  @spec create_reimbursement(Book.t(), map()) ::
+  @spec create_reimbursement(Book.t(), BookMember.t(), map()) ::
           {:ok, MoneyTransfer.t()} | {:error, Ecto.Changeset.t()}
-  def create_reimbursement(%Book{} = book, attrs) do
+  def create_reimbursement(%Book{} = book, %BookMember{} = creator, attrs) do
     %MoneyTransfer{
       book_id: book.id,
+      creator_id: creator.id,
       type: :reimbursement,
       balance_means: :divide_equally
     }

--- a/lib/app_web/live/books/book_reimbursement_creation_live.ex
+++ b/lib/app_web/live/books/book_reimbursement_creation_live.ex
@@ -131,10 +131,10 @@ defmodule AppWeb.BookReimbursementCreationLive do
   end
 
   def handle_event("submit", %{"reimbursement" => reimbursement_params}, socket) do
-    book = socket.assigns.book
+    %{book: book, current_member: current_member} = socket.assigns
     transfer_params = to_transfer_params(reimbursement_params)
 
-    case Transfers.create_reimbursement(book, transfer_params) do
+    case Transfers.create_reimbursement(book, current_member, transfer_params) do
       {:ok, _money_transfer} ->
         {:noreply, push_navigate(socket, to: ~p"/books/#{book}/balance")}
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -69,7 +69,7 @@ alias App.Transfers
   })
 
 {:ok, _reimbursement} =
-  Transfers.create_reimbursement(book, %{
+  Transfers.create_reimbursement(book, member_3, %{
     label: "Reimbursement from Member 2 to Anacounts",
     amount: Decimal.new("20.00"),
     date: ~D[2026-07-05],

--- a/test/app/transfers_test.exs
+++ b/test/app/transfers_test.exs
@@ -468,18 +468,25 @@ defmodule App.TransfersTest do
     end
   end
 
-  describe "create_reimbursement/2" do
+  describe "create_reimbursement/3" do
     setup do
       book = book_fixture()
       member1 = book_member_fixture(book)
       member2 = book_member_fixture(book)
+      creator = book_member_fixture(book)
 
-      %{book: book, member1: member1, member2: member2}
+      %{book: book, member1: member1, member2: member2, creator: creator}
     end
 
-    test "creates a reimbursement in a book", %{book: book, member1: member1, member2: member2} do
+    test "creates a reimbursement in a book",
+         %{
+           book: book,
+           member1: member1,
+           member2: member2,
+           creator: creator
+         } do
       assert {:ok, money_transfer} =
-               Transfers.create_reimbursement(book, %{
+               Transfers.create_reimbursement(book, creator, %{
                  label: "Reimbursement from member1 to member2",
                  amount: Decimal.new(100),
                  date: ~D[2020-06-29],
@@ -493,12 +500,20 @@ defmodule App.TransfersTest do
       assert money_transfer.date == ~D[2020-06-29]
       assert money_transfer.tenant_id == member1.id
       assert money_transfer.balance_means == :divide_equally
+      assert money_transfer.creator_id == creator.id
     end
 
-    test "cannot create a payment or an income", %{book: book, member1: member1, member2: member2} do
+    test "cannot create a payment or an income",
+         %{
+           book: book,
+           member1: member1,
+           member2: member2,
+           creator: creator
+         } do
       assert {:ok, money_transfer} =
                Transfers.create_reimbursement(
                  book,
+                 creator,
                  money_transfer_attributes(
                    type: :payment,
                    tenant_id: member1.id,
@@ -509,14 +524,17 @@ defmodule App.TransfersTest do
       assert money_transfer.type == :reimbursement
     end
 
-    test "cannot create a money transfer weighted by income", %{
-      book: book,
-      member1: member1,
-      member2: member2
-    } do
+    test "cannot create a money transfer weighted by income",
+         %{
+           book: book,
+           member1: member1,
+           member2: member2,
+           creator: creator
+         } do
       assert {:ok, money_transfer} =
                Transfers.create_reimbursement(
                  book,
+                 creator,
                  money_transfer_attributes(
                    balance_means: :weighted_by_income,
                    tenant_id: member1.id,
@@ -527,10 +545,16 @@ defmodule App.TransfersTest do
       assert money_transfer.balance_means == :divide_equally
     end
 
-    test "cannot create a money transfer withour peers", %{book: book, member1: member1} do
+    test "cannot create a money transfer withour peers",
+         %{
+           book: book,
+           member1: member1,
+           creator: creator
+         } do
       assert_raise Ecto.ChangeError, "A reimbursement must have exactly one peer", fn ->
         Transfers.create_reimbursement(
           book,
+          creator,
           money_transfer_attributes(
             tenant_id: member1.id,
             peers: []
@@ -539,13 +563,19 @@ defmodule App.TransfersTest do
       end
     end
 
-    test "cannot create a money transfer with multiple peers", %{book: book, member1: member1} do
+    test "cannot create a money transfer with multiple peers",
+         %{
+           book: book,
+           member1: member1,
+           creator: creator
+         } do
       member2 = book_member_fixture(book)
       member3 = book_member_fixture(book)
 
       assert_raise Ecto.ChangeError, "A reimbursement must have exactly one peer", fn ->
         Transfers.create_reimbursement(
           book,
+          creator,
           money_transfer_attributes(
             tenant_id: member1.id,
             peers: [%{member_id: member2.id}, %{member_id: member3.id}]
@@ -554,13 +584,16 @@ defmodule App.TransfersTest do
       end
     end
 
-    test "cannot create a money transfer with the only peer being the tenant", %{
-      book: book,
-      member1: member1
-    } do
+    test "cannot create a money transfer with the only peer being the tenant",
+         %{
+           book: book,
+           member1: member1,
+           creator: creator
+         } do
       assert {:error, changeset} =
                Transfers.create_reimbursement(
                  book,
+                 creator,
                  money_transfer_attributes(
                    tenant_id: member1.id,
                    peers: [%{member_id: member1.id}]

--- a/test/support/fixtures/transfers_fixtures.ex
+++ b/test/support/fixtures/transfers_fixtures.ex
@@ -18,7 +18,10 @@ defmodule App.TransfersFixtures do
   end
 
   def money_transfer_fixture(book, attrs \\ %{}) do
-    %MoneyTransfer{book_id: book.id}
+    %MoneyTransfer{
+      book_id: book.id,
+      creator_id: attrs[:tenant_id]
+    }
     |> Map.merge(money_transfer_attributes(attrs))
     |> Repo.insert!()
   end


### PR DESCRIPTION
## Why?

Reimbursements were created with a creator book member. That was a mistake! Let's fill it up starting now.

## What?

Add creator to reimbursments.
