### PR TITLE
chore(transfers, repo): make `money_transfers.creator_id` not null

### DIFF
--- a/lib/app/transfers/money_transfer.ex
+++ b/lib/app/transfers/money_transfer.ex
@@ -46,6 +46,8 @@ defmodule App.Transfers.MoneyTransfer do
     field :date, :date, read_after_writes: true
 
     field :book_id, :integer
+    # Contains the ID of the book member who created the money transfer. At the time of
+    # writing, the field is only used to filter transfers in the interface.
     field :creator_id, :integer
     belongs_to :tenant, BookMember
 

--- a/priv/repo/migrations/20260719181848_make_money_transfers_creator_id_not_nullable.exs
+++ b/priv/repo/migrations/20260719181848_make_money_transfers_creator_id_not_nullable.exs
@@ -1,0 +1,8 @@
+defmodule App.Repo.Migrations.MakeMoneyTransfersCreatorIDNotNullable do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE money_transfers ALTER COLUMN creator_id SET NOT NULL",
+            "ALTER TABLE money_transfers ALTER COLUMN creator_id DROP NOT NULL"
+  end
+end


### PR DESCRIPTION
## Why?

Second step to strengthening the foreign keys in the `books` table and related (first step: #513).

## What?

Set `money_transfers.creator_id` not null.
