### PR TITLE
chore(*, repo): strengthen foreign-keys

### DIFF
--- a/lib/app/books.ex
+++ b/lib/app/books.ex
@@ -10,6 +10,7 @@ defmodule App.Books do
   alias App.Books.BookMember
   alias App.Books.InvitationToken
   alias App.Repo
+  alias App.Transfers.MoneyTransfer
 
   ## Database getters
 
@@ -164,7 +165,23 @@ defmodule App.Books do
   """
   @spec delete_book!(Book.t()) :: Book.t()
   def delete_book!(%Book{} = book) do
-    Repo.delete!(book)
+    {:ok, book} =
+      Repo.transact(fn ->
+        # Book members are referenced by the following foreign keys, restricting their
+        # deletion to avoid data inconsistencies:
+        # - money_transfers_tenant_id_fkey (ON DELETE RESTRICT)
+        # - money_transfers_creator_id_fkey (ON DELETE RESTRICT)
+        # - transfers_peers_member_id_fkey (ON DELETE RESTRICT)
+        #
+        # Money transfers must therefore be deleted before book members to ensure members
+        # are no longer "tenant", "creator" or "peer", and can safely be deleted.
+        book |> MoneyTransfer.transfers_of_book_query() |> Repo.delete_all()
+        book |> BookMember.book_query() |> Repo.delete_all()
+
+        {:ok, Repo.delete!(book)}
+      end)
+
+    book
   end
 
   ## Close / Reopen

--- a/priv/repo/migrations/20260719190000_strengthen_book_foreign_keys.exs
+++ b/priv/repo/migrations/20260719190000_strengthen_book_foreign_keys.exs
@@ -1,0 +1,38 @@
+defmodule App.Repo.Migrations.StrengthenBookForeignKeys do
+  use Ecto.Migration
+
+  def change do
+    execute """
+            ALTER TABLE book_members
+            DROP CONSTRAINT book_members_book_id_fkey,
+            ADD FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE
+            """,
+            """
+            ALTER TABLE book_members
+            DROP CONSTRAINT book_members_book_id_fkey,
+            ADD FOREIGN KEY (book_id) REFERENCES books(id) ON UPDATE CASCADE ON DELETE CASCADE
+            """
+
+    execute """
+            ALTER TABLE money_transfers
+            DROP CONSTRAINT money_transfers_creator_id_fkey,
+            ADD FOREIGN KEY (creator_id) REFERENCES book_members(id) ON DELETE RESTRICT
+            """,
+            """
+            ALTER TABLE money_transfers
+            DROP CONSTRAINT money_transfers_creator_id_fkey,
+            ADD FOREIGN KEY (creator_id) REFERENCES book_members(id) ON DELETE SET NULL
+            """
+
+    execute """
+            ALTER TABLE transfers_peers
+            DROP CONSTRAINT transfers_peers_member_id_fkey,
+            ADD FOREIGN KEY (member_id) REFERENCES book_members(id) ON DELETE RESTRICT
+            """,
+            """
+            ALTER TABLE transfers_peers
+            DROP CONSTRAINT transfers_peers_member_id_fkey,
+            ADD FOREIGN KEY (member_id) REFERENCES book_members(id) ON DELETE CASCADE
+            """
+  end
+end

--- a/test/app/books_test.exs
+++ b/test/app/books_test.exs
@@ -4,6 +4,7 @@ defmodule App.BooksTest do
   import App.AccountsFixtures
   import App.Books.MembersFixtures
   import App.BooksFixtures
+  import App.TransfersFixtures
 
   alias App.Books
   alias App.Books.Book
@@ -224,7 +225,7 @@ defmodule App.BooksTest do
 
   ## Deletion
 
-  describe "delete_book!/2" do
+  describe "delete_book!/1" do
     setup do
       %{book: book_fixture()}
     end
@@ -233,6 +234,52 @@ defmodule App.BooksTest do
       deleted = Books.delete_book!(book)
       assert deleted.id == book.id
       assert Repo.reload(book) == nil
+    end
+
+    test "deletes book members with no dependent money transfers", %{book: book} do
+      member = book_member_fixture(book)
+
+      Books.delete_book!(book)
+
+      assert Repo.reload(member) == nil
+    end
+
+    test "deletes money transfers along with their tenant and creator book members",
+         %{book: book} do
+      tenant = book_member_fixture(book)
+      creator = book_member_fixture(book)
+      transfer = money_transfer_fixture(book, tenant_id: tenant.id, creator_id: creator.id)
+
+      Books.delete_book!(book)
+
+      assert Repo.reload(transfer) == nil
+      assert Repo.reload(tenant) == nil
+      assert Repo.reload(creator) == nil
+    end
+
+    test "deletes transfer peers along with the peer book member", %{book: book} do
+      tenant = book_member_fixture(book)
+      peer_member = book_member_fixture(book)
+      transfer = money_transfer_fixture(book, tenant_id: tenant.id)
+      peer = peer_fixture(transfer, member_id: peer_member.id)
+
+      Books.delete_book!(book)
+
+      assert Repo.reload(peer) == nil
+      assert Repo.reload(peer_member) == nil
+    end
+
+    test "does not delete data belonging to other books", %{book: book} do
+      other_book = book_fixture()
+      other_member = book_member_fixture(other_book)
+      other_transfer = money_transfer_fixture(other_book, tenant_id: other_member.id)
+      other_peer = peer_fixture(other_transfer, member_id: other_member.id)
+
+      Books.delete_book!(book)
+
+      assert Repo.reload(other_member) == other_member
+      assert Repo.reload(other_transfer) == other_transfer
+      assert Repo.reload(other_peer) == other_peer
     end
   end
 


### PR DESCRIPTION
## Why?

Some foreign keys around `book_members` allowed behaviours that should not be possible in the application. This did not cause problem per se, but using the database to enforce application constraint can help a great deal in case of code issues.

## What?

Make some foreign keys more restrictive regarding deletion.
